### PR TITLE
Add CampaignRates class and corresponding tests

### DIFF
--- a/admitad/items/__init__.py
+++ b/admitad/items/__init__.py
@@ -18,3 +18,4 @@ from admitad.items.retag import *
 from admitad.items.broken_links import *
 from admitad.items.tickets import *
 from admitad.items.promo_offers import *
+from admitad.items.campaign_rates import *

--- a/admitad/items/campaign_rates.py
+++ b/admitad/items/campaign_rates.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from admitad.items.base import Item
+
+
+__all__ = [
+    'CampaignRates',
+]
+
+
+class CampaignRates(Item):
+    """
+    Get campaign rates, tariffs and actions information
+
+    """
+
+    SCOPE = 'campaign_rates'
+
+    URL = Item.prepare_url('campaign_rates/%(campaign_id)s/rates')
+
+    def get(self, campaign_id: int, **kwargs: dict) -> dict:
+        """
+        Get campaign rates, tariffs and actions information
+
+        Args:
+            campaign_id (int): Campaign ID
+
+        Returns:
+            dict: Campaign rates information with actions, tariffs and rates
+
+        """
+        request_data = {
+            'url': self.URL,
+            'campaign_id': Item.sanitize_id(campaign_id)
+        }
+
+        return self.transport.get().request(**request_data)

--- a/admitad/items/coupons.py
+++ b/admitad/items/coupons.py
@@ -16,6 +16,7 @@ class CouponsBase(Item):
         'campaign_category': lambda x: Item.sanitize_integer_array(x, 'campaign_category', blank=True),
         'category': lambda x: Item.sanitize_integer_array(x, 'category', blank=True),
         'type': lambda x: Item.sanitize_string_value(x, 'type', blank=True),
+        'is_tracking_promocode': lambda x: Item.sanitize_bool_value(x, 'tracking_promocode', blank=True),
     }
 
 

--- a/admitad/items/coupons.py
+++ b/admitad/items/coupons.py
@@ -17,6 +17,7 @@ class CouponsBase(Item):
         'category': lambda x: Item.sanitize_integer_array(x, 'category', blank=True),
         'type': lambda x: Item.sanitize_string_value(x, 'type', blank=True),
         'is_tracking_promocode': lambda x: Item.sanitize_bool_value(x, 'tracking_promocode', blank=True),
+        'species': lambda x: Item.sanitize_string_array(x, 'species', blank=True),
     }
 
 

--- a/admitad/tests/test_campaign_rates.py
+++ b/admitad/tests/test_campaign_rates.py
@@ -1,0 +1,130 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import unittest
+import responses
+
+from admitad.items import CampaignRates
+from admitad.tests.base import BaseTestCase
+
+
+class CampaignRatesTestCase(BaseTestCase):
+
+    def test_get_campaign_rates(self):
+        campaign_id = 1
+        with responses.RequestsMock() as resp:
+            resp.add(
+                resp.GET,
+                self.prepare_url(CampaignRates.URL, campaign_id=campaign_id),
+                json={
+                    'campaign_id': campaign_id,
+                    'actions': [{
+                        'action_id': 1,
+                        'action_name': 'Sale',
+                        'action_code': 'sale',
+                        'action_type': 'sale',
+                        'system_commission': '10.00',
+                        'system_commission_from_cart': None,
+                        'tariffs': [{
+                            'tariff_id': 1,
+                            'tariff_name': 'Standard Tariff',
+                            'tariff_code': 'TAR001',
+                            'default': True,
+                            'rates': [{
+                                'price_s': '100.00$',
+                                'size': '50.00$',
+                                'country': 'Russia'
+                            }, {
+                                'price_s': '200.00$',
+                                'size': '100.00$',
+                                'country': 'USA'
+                            }]
+                        }]
+                    }]
+                },
+                status=200
+            )
+            result = self.client.CampaignRates.get(campaign_id)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['campaign_id'], campaign_id)
+        self.assertIn('actions', result)
+        self.assertEqual(len(result['actions']), 1)
+        self.assertEqual(result['actions'][0]['action_id'], 1)
+        self.assertEqual(result['actions'][0]['action_name'], 'Sale')
+        self.assertIn('tariffs', result['actions'][0])
+        self.assertEqual(len(result['actions'][0]['tariffs']), 1)
+        self.assertIn('rates', result['actions'][0]['tariffs'][0])
+        self.assertEqual(len(result['actions'][0]['tariffs'][0]['rates']), 2)
+
+    def test_get_campaign_rates_with_multiple_actions(self):
+        campaign_id = 2
+        with responses.RequestsMock() as resp:
+            resp.add(
+                resp.GET,
+                self.prepare_url(CampaignRates.URL, campaign_id=campaign_id),
+                json={
+                    'campaign_id': campaign_id,
+                    'actions': [
+                        {
+                            'action_id': 1,
+                            'action_name': 'Sale',
+                            'action_code': 'sale',
+                            'action_type': 'sale',
+                            'system_commission': '10.00',
+                            'system_commission_from_cart': None,
+                            'tariffs': []
+                        },
+                        {
+                            'action_id': 2,
+                            'action_name': 'Lead',
+                            'action_code': 'lead',
+                            'action_type': 'lead',
+                            'system_commission': None,
+                            'system_commission_from_cart': '5.00',
+                            'tariffs': [{
+                                'tariff_id': 2,
+                                'tariff_name': 'Lead Tariff',
+                                'tariff_code': 'TAR002',
+                                'default': False,
+                                'rates': [{
+                                    'price_s': '50.00$',
+                                    'size': '25.00$',
+                                    'country': None
+                                }]
+                            }]
+                        }
+                    ]
+                },
+                status=200
+            )
+            result = self.client.CampaignRates.get(campaign_id)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['campaign_id'], campaign_id)
+        self.assertEqual(len(result['actions']), 2)
+        self.assertEqual(result['actions'][0]['action_code'], 'sale')
+        self.assertEqual(result['actions'][1]['action_code'], 'lead')
+
+    def test_get_campaign_rates_with_empty_actions(self):
+        campaign_id = 3
+        with responses.RequestsMock() as resp:
+            resp.add(
+                resp.GET,
+                self.prepare_url(CampaignRates.URL, campaign_id=campaign_id),
+                json={
+                    'campaign_id': campaign_id,
+                    'actions': []
+                },
+                status=200
+            )
+            result = self.client.CampaignRates.get(campaign_id)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result['campaign_id'], campaign_id)
+        self.assertEqual(result['actions'], [])
+
+    def test_get_campaign_rates_invalid_id(self):
+        campaign_id = 0
+        with self.assertRaises(ValueError):
+            self.client.CampaignRates.get(campaign_id)


### PR DESCRIPTION
- Introduced CampaignRates class for retrieving campaign rates, tariffs, and actions information.
- Implemented the get method with detailed type hints and Google-style docstrings.
- Added comprehensive test cases for various scenarios, including valid and invalid campaign IDs, in test_campaign_rates.py.
- Updated imports in __init__.py to include the new CampaignRates class.